### PR TITLE
feat: allow specifying existing token secret

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --helm-lint-extra-args '--set mezmoApiAccessToken=my-token'
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
@@ -42,4 +42,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args '--set mezmoApiAccessToken=my-token'

--- a/charts/edge/Chart.yaml
+++ b/charts/edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://app.mezmo.com/assets/img/mz-logo-square-128.png
 description: A Helm chart for deploying Mezmo Edge
 type: application
 appVersion: "3.7.3"
-version: 1.0.2
+version: 1.0.3
 maintainers:
   - name: Mezmo
     email: help@mezmo.com

--- a/charts/edge/README.md
+++ b/charts/edge/README.md
@@ -31,7 +31,8 @@ helm install edge mezmo/edge \
 
 | **Key**                      | **Type** | **Default**      | **Description**
 | ---------------------------- | -------- | ---------------- | ----------------------------------------------------------------------
-| mezmoApiAccessToken          | string   |                  | Your Mezmo API access token
+| mezmoApiAccessToken       | string   |                 | Your Mezmo API access token. This has a lower precedence than `mezmoApiAccessSecret`
+| mezmoApiAccessSecret      | string   |                 | Existing secret containing your Mezmo API access token. Given secret should have the token in a key named `api-access-token` and be in the same namespace as the Edge instance. This takes precedence over `mezmoApiAccessToken`
 | mezmoDeploymentGroup         | string   |                  | Deployment group to apply to this Edge instance. Leaving undefined pulls all Edge pipelines for the org
 | mezmoApiScheme               | string   | "https"          | The scheme to use for the Mezmo API URL
 | mezmoApiHost                 | string   | "api.mezmo.com"  | The hostname(:port) of the Mezmo API

--- a/charts/edge/templates/NOTES.txt
+++ b/charts/edge/templates/NOTES.txt
@@ -1,13 +1,3 @@
-{{- if not .Values.mezmoApiAccessToken -}}
-#####################################################################
-###  ERROR: Please specify an access token `mezmoApiAccessToken`  ###
-#####################################################################
-
-Try:
-
-  $ helm upgrade --reuse-values --set mezmoApiAccessToken=<ACCESS_TOKEN> {{ .Release.Name }} mezmo/{{ .Chart.Name }}
-
-{{ else -}}
 Welcome to Edge {{ .Chart.Version }} release "{{ .Release.Name }}".
 
 ----------------------------------------------------------------
@@ -37,7 +27,6 @@ To run selected pipelines, apply a Deployment Group in the Pipeline Settings pag
 
 This Edge instance is running the "{{ .Values.mezmoDeploymentGroup}}" deployment group pipelines.
 
-{{end -}}
 {{end -}}
 
 -

--- a/charts/edge/templates/_helpers.tpl
+++ b/charts/edge/templates/_helpers.tpl
@@ -102,3 +102,18 @@ deployment_group: {{ .Values.mezmoDeploymentGroup | quote }}
 ports: {{- include "edge.sourcePorts" . | nindent 2 }}
 version: edge-{{ $.Chart.Version }}
 {{- end }}
+
+{{/*
+Secret file name to use
+*/}}
+{{- define "edge.tokenSecretRef" -}}
+{{- if .Values.mezmoApiAccessSecret }}
+name: {{ .Values.mezmoApiAccessSecret }}
+{{- else }}
+{{- if .Values.mezmoApiAccessToken }}
+name: {{ include "edge.fullname" . }}
+{{- else }}
+{{ fail .Values.tokenSecretRefError }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/edge/templates/secret-api-access-token.yaml
+++ b/charts/edge/templates/secret-api-access-token.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mezmoApiAccessToken -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
 type: Opaque
 data:
   api-access-token: {{ default "MISSING" .Values.mezmoApiAccessToken | b64enc | quote }}
+{{- end }}

--- a/charts/edge/templates/statefulset.yaml
+++ b/charts/edge/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
           - name: MEZMO_LOCAL_DEPLOY_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ include "edge.fullname" . }}
+                {{ include "edge.tokenSecretRef" . | nindent 16  }}
                 key: api-access-token
           - name: MEZMO_METRICS_ENDPOINT_URL
             value: "{{include "edge.mezmoApiBaseUrl" . }}/v3/pipeline/account/local-deploy/metric/usage?edge_id={{include "edge.Id" . | urlquery }}"

--- a/charts/edge/values.yaml
+++ b/charts/edge/values.yaml
@@ -15,6 +15,9 @@ mezmoApiHost: "api.mezmo.com"
 # Your Mezmo API Access Token
 mezmoApiAccessToken: ""
 
+# Secret containing your Mezmo API Access Token
+mezmoApiAccessSecret: ""
+
 # Deployment group for this Edge instance.
 # Setting configures only pipelines tagged with this group name.
 # Leaving unset configures all Edge pipelines defined in your org.
@@ -83,3 +86,14 @@ maxMemBufferEvents: 0
 # as floats and rendering scientific notation
 reduceByteThresholdPerState: "104857600"
 reduceByteThresholdAllStates: "1073741824"
+tokenSecretRefError: |+
+
+
+  ######################################################################
+  ###  ERROR: Please specify an access token (`mezmoApiAccessToken`) ###
+  ###    or a secret containing a token (`mezmoApiAccessSecret`)     ###
+  ######################################################################
+
+  Try:
+
+    $ helm upgrade --reuse-values --set mezmoApiAccessToken=<ACCESS_TOKEN> {{ .Release.Name }} mezmo/{{ .Chart.Name }}


### PR DESCRIPTION
Adds a `mezmoApiAccessSecret` option to use instead of a manually specified access token

ref: LOG-19426