### PR TITLE
fix: make reduce defaults strings in values.yaml

### DIFF
--- a/charts/edge/Chart.yaml
+++ b/charts/edge/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://app.mezmo.com/assets/img/mz-logo-square-128.png
 description: A Helm chart for deploying Mezmo Edge
 type: application
 appVersion: "3.7.3"
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: Mezmo
     email: help@mezmo.com

--- a/charts/edge/templates/statefulset.yaml
+++ b/charts/edge/templates/statefulset.yaml
@@ -58,9 +58,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: MEZMO_API_HOST
-            value: "{{ .Values.mezmoApiHost }}"
+            value: {{ .Values.mezmoApiHost | quote }}
           - name: MEZMO_API_SCHEME
-            value: "{{ .Values.mezmoApiScheme }}"
+            value: {{ .Values.mezmoApiScheme | quote }}
           - name: MEZMO_LOCAL_DEPLOY_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
@@ -73,9 +73,9 @@ spec:
           - name: MEZMO_TASKS_POST_ENDPOINT_URL
             value: "{{include "edge.mezmoApiBaseUrl" . }}/v3/pipeline/account/local-deploy/tasks/:task_id/results"
           - name: MEZMO_EDGE_ID
-            value: "{{include "edge.Id" . }}"
+            value: {{include "edge.Id" . | quote }}
           - name: VECTOR_LOG
-            value: "{{ .Values.logLevel }}"
+            value: {{ .Values.logLevel | quote }}
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -94,16 +94,16 @@ spec:
             value: "1"
           {{- if .Values.maxDiskBufferBytes }}
           - name: MEZMO_DISK_BUFFER_MAX_BYTES
-            value: "{{ .Values.maxDiskBufferBytes }}"
+            value: {{ .Values.maxDiskBufferBytes | quote }}
           {{- end }}
           {{- if .Values.maxMemBufferEvents }}
           - name: MEZMO_MEM_BUFFER_MAX_EVENTS
-            value: "{{ .Values.maxMemBufferEvents }}"
+            value: {{ .Values.maxMemBufferEvents | quote }}
           {{- end }}
           - name: REDUCE_BYTE_THRESHOLD_PER_STATE
-            value: "{{ .Values.reduceByteThresholdPerState }}"
+            value: {{ .Values.reduceByteThresholdPerState | quote }}
           - name: REDUCE_BYTE_THRESHOLD_ALL_STATES
-            value: "{{ .Values.reduceByteThresholdAllStates }}"
+            value: {{ .Values.reduceByteThresholdAllStates | quote }}
           args:
             - --config-dir
             - /etc/vector/

--- a/charts/edge/values.yaml
+++ b/charts/edge/values.yaml
@@ -79,5 +79,7 @@ pvcName: ""
 maxDiskBufferBytes: 0
 maxMemBufferEvents: 0
 
-reduceByteThresholdPerState: 104857600
-reduceByteThresholdAllStates: 1073741824
+# defaults defined as strings to avoid helm treating
+# as floats and rendering scientific notation
+reduceByteThresholdPerState: "104857600"
+reduceByteThresholdAllStates: "1073741824"


### PR DESCRIPTION
This avoids them being treated as large floating point numbers and rendering with scientific notation.

ref: LOG-19501