### PR TITLE
chore: Bump vector version to 3.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,26 @@
 
 Helm charts for Mezmo products.
 
-## How to use the Helm repository
+## How to install the Helm repository
 
 You need to add this repository to your Helm repositories:
 
 ```shell
 helm repo add mezmo https://helm.mezmo.com
 helm repo update
+
+# Use the default port range, 8000-8010
+helm install edge mezmo/edge \
+  --set mezmoApiAccessToken=<MEZMO_API_ACCESS_TOKEN>
 ```
 
-See READMEs for individual charts below for usage details on each.
+## Upgrading
+
+When a new version is available, update the helm charts and upgrade the instance.
+
+```shell
+helm repo update mezmo
+helm upgrade --reuse-values edge mezmo/edge
+```
+
+See the [chart README](charts/edge/README.md) for more usage details.

--- a/charts/edge/Chart.yaml
+++ b/charts/edge/Chart.yaml
@@ -4,8 +4,8 @@ home: https://www.mezmo.com
 icon: https://app.mezmo.com/assets/img/mz-logo-square-128.png
 description: A Helm chart for deploying Mezmo Edge
 type: application
-appVersion: "3.12.0"
-version: 1.1.0
+appVersion: "3.14.1"
+version: 1.2.0
 maintainers:
   - name: Mezmo
     email: help@mezmo.com

--- a/charts/edge/README.md
+++ b/charts/edge/README.md
@@ -13,11 +13,14 @@
 
 ```sh
 helm install edge mezmo/edge \
-  --namespace <MY_NAMESPACE> \
   --set mezmoApiAccessToken=<MEZMO_API_ACCESS_TOKEN>
 ```
 
-By default ports in the range [8000, 8010] are configured. See `service.sourcePorts.*` values for configuring different ranges. For example, to configure with no contiguous range and two ports (syslog and http) exposed:
+By default ports in the range [8000, 8010] are configured. See `service.sourcePorts.*` values for configuring different ranges.
+
+## Specifying a different port range
+You may specify a different port range if desired.
+For example, to configure with no contiguous range and two ports (syslog and http) exposed:
 
 ```sh
 helm install edge mezmo/edge \
@@ -25,6 +28,16 @@ helm install edge mezmo/edge \
   --set service.sourcePorts.end=0 \
   --set service.sourcePorts.list="{514,80}"
 ```
+
+Or choose a custom range:
+
+```shell
+helm install edge mezmo/edge \
+  --set mezmoApiAccessToken=<MEZMO_API_ACCESS_TOKEN> \
+  --set service.sourcePorts.start=20000 \
+  --set service.sourcePorts.end=20020
+```
+
 ## Configuration
 
 ### Values
@@ -36,6 +49,7 @@ helm install edge mezmo/edge \
 | mezmoDeploymentGroup         | string   |                  | Deployment group to apply to this Edge instance. Leaving undefined pulls all Edge pipelines for the org
 | mezmoApiScheme               | string   | "https"          | The scheme to use for the Mezmo API URL
 | mezmoApiHost                 | string   | "api.mezmo.com"  | The hostname(:port) of the Mezmo API
+| namespace                    | string   |                  | Optional namespace for compartmentalization
 | logLevel                     | string   | info             | Controls the logging verbosity of the deployment
 | autoscaling.enabled          | boolean  | false            | Whether or not to enable a HorizontalPodAutoscaler for this deployment
 | service.sourcePorts.start    | int      | 8000             | The start of the port range (inclusive [start, end])


### PR DESCRIPTION
Includes a fix for a new feature added to the SaaS that allows capturing data on errors. Not yet available in Edge, but nevertheless, breaking without this bump.